### PR TITLE
CMakeLists.txt: Revert introducing configure switch -Denable_coverage…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ set(SERVICE_LIB ${PACKAGE})
 set(SERVICE_EXEC "${PACKAGE}-service")
 
 option(enable_tests "Build the package's automatic tests." ON)
-option(enable_coverage "Generate code coverage reports." OFF)
 
 set(CMAKE_INSTALL_PKGLIBEXECDIR "${CMAKE_INSTALL_LIBEXECDIR}/${CMAKE_PROJECT_NAME}")
 set(CMAKE_INSTALL_FULL_PKGLIBEXECDIR "${CMAKE_INSTALL_FULL_LIBEXECDIR}/${CMAKE_PROJECT_NAME}")
@@ -81,12 +80,10 @@ add_subdirectory(po)
 if(${enable_tests})
   enable_testing()
   add_subdirectory(tests)
-  if (${enable_coverage})
-    find_package(CoverageReport)
-    ENABLE_COVERAGE_REPORT(
-      TARGETS ${SERVICE_LIB} ${SERVICE_EXEC}
-      TESTS ${COVERAGE_TEST_TARGETS}
-      FILTER /usr/include ${CMAKE_BINARY_DIR}/*
-    )
-  endif()
+  find_package(CoverageReport)
+  ENABLE_COVERAGE_REPORT(
+    TARGETS ${SERVICE_LIB} ${SERVICE_EXEC}
+    TESTS ${COVERAGE_TEST_TARGETS}
+    FILTER /usr/include ${CMAKE_BINARY_DIR}/*
+  )
 endif()

--- a/src/adbd-client.cpp
+++ b/src/adbd-client.cpp
@@ -107,7 +107,7 @@ private:
 
     void on_public_key_response(PKResponse response)
     {
-        g_debug("%s thread %p got response %d", G_STRLOC, g_thread_self(), int(response));
+        g_debug("%s thread %p got response %d", G_STRLOC, (void*)g_thread_self(), int(response));
 
         // set m_pkresponse and wake up the waiting worker thread
         m_pkresponse = response;
@@ -125,11 +125,11 @@ private:
 
         while (!g_cancellable_is_cancelled(m_cancellable))
         {
-            g_debug("%s thread %p creating a client socket to '%s'", G_STRLOC, g_thread_self(), socket_path.c_str());
+            g_debug("%s thread %p creating a client socket to '%s'", G_STRLOC, (void*)g_thread_self(), socket_path.c_str());
             auto socket = create_client_socket(socket_path);
             bool got_valid_req = false;
 
-            g_debug("%s thread %p calling read_request", g_thread_self(), G_STRLOC);
+            g_debug("%s thread %p calling read_request", G_STRLOC, (void*)g_thread_self());
             std::string reqstr;
             if (socket != nullptr)
                 reqstr = read_request(socket);
@@ -139,7 +139,7 @@ private:
             if (reqstr.substr(0,2) == "PK") {
                 PKResponse response = PKResponse::DENY;
                 const auto public_key = reqstr.substr(2);
-                g_debug("%s thread %p got pk [%s]", G_STRLOC, g_thread_self(), public_key.c_str());
+                g_debug("%s thread %p got pk [%s]", G_STRLOC, (void*)g_thread_self(), public_key.c_str());
                 if (!public_key.empty()) {
                     got_valid_req = true;
                     std::unique_lock<std::mutex> lk(m_pkresponse_mutex);
@@ -151,7 +151,7 @@ private:
                     });
                     response = m_pkresponse;
                     g_debug("%s thread %p got response '%d', is-cancelled %d", G_STRLOC,
-                            g_thread_self(),
+                            (void*)g_thread_self(),
                             int(response),
                             int(g_cancellable_is_cancelled(m_cancellable)));
                 }

--- a/src/indicator.h
+++ b/src/indicator.h
@@ -64,10 +64,10 @@ public:
   SimpleProfile(const char* name, const std::shared_ptr<GMenuModel>& menu): m_name(name), m_menu(menu) {}
   virtual ~SimpleProfile();
 
-  std::string name() const {return m_name;}
+  std::string name() const override {return m_name;}
   core::Property<Header>& header() {return m_header;}
-  const core::Property<Header>& header() const {return m_header;}
-  std::shared_ptr<GMenuModel> menu_model() const {return m_menu;}
+  const core::Property<Header>& header() const override {return m_header;}
+  std::shared_ptr<GMenuModel> menu_model() const override {return m_menu;}
 
 protected:
   const std::string m_name;

--- a/src/rotation-lock.h
+++ b/src/rotation-lock.h
@@ -30,9 +30,9 @@ public:
   RotationLockIndicator();
   ~RotationLockIndicator();
 
-  const char* name() const;
-  GSimpleActionGroup* action_group() const;
-  std::vector<std::shared_ptr<Profile>> profiles() const;
+  const char* name() const override;
+  GSimpleActionGroup* action_group() const override;
+  std::vector<std::shared_ptr<Profile>> profiles() const override;
 
 protected:
   class Impl;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 add_compile_options(${CXX_WARNING_ARGS})
 
-add_test(cppcheck cppcheck --enable=all -USCHEMA_DIR --error-exitcode=2 --inline-suppr -I${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests)
+add_test(cppcheck cppcheck --force --enable=all -USCHEMA_DIR --error-exitcode=2 --suppress=missingInclude --suppress=unusedFunction --suppress=unreadVariable --library=qt --inline-suppr -I${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests)
 
 add_subdirectory(integration)
 add_subdirectory(unit)

--- a/tests/unit/adbd-client-test.cpp
+++ b/tests/unit/adbd-client-test.cpp
@@ -38,7 +38,7 @@ protected:
 
     std::shared_ptr<std::string> m_tmpdir;
 
-    void SetUp()
+    void SetUp() override
     {
         super::SetUp();
 

--- a/tests/unit/adbd-client-test.cpp
+++ b/tests/unit/adbd-client-test.cpp
@@ -86,7 +86,7 @@ TEST_F(AdbdClientFixture, SocketPlumbing)
         EXPECT_EQ(test.expected_pk, pk);
         ASSERT_EQ(1, adbd_server->m_responses.size());
         EXPECT_EQ(test.expected_response, adbd_server->m_responses.front());
-   
+
         // cleanup
         connection.disconnect();
         adbd_client.reset();

--- a/tests/unit/rotation-lock-test.cpp
+++ b/tests/unit/rotation-lock-test.cpp
@@ -28,12 +28,12 @@ private:
 
 protected:
 
-  void SetUp()
+  void SetUp() override
   {
     super::SetUp();
   }
 
-  void TearDown()
+  void TearDown() override
   {
     super::TearDown();
   }


### PR DESCRIPTION
…, the coverage enablement is enabled via CMAKE_BUILD_TYPE=coverage env var.

Note: However, when trying a coverage build, I get this failure (not this is PR branch includes the proposed changes from #6):

```
[mike@minobo ayatana-indicator-display (pr/fix-unit-tests)]$ make test && make coverage
Running tests...
Test project /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display
    Start 1: cppcheck
1/6 Test #1: cppcheck .........................   Passed    1.59 sec
    Start 2: usb-manager-test
2/6 Test #2: usb-manager-test .................   Passed    2.84 sec
    Start 3: adbd-client-test
3/6 Test #3: adbd-client-test .................   Passed    0.28 sec
    Start 4: rotation-lock-test
4/6 Test #4: rotation-lock-test ...............   Passed    0.14 sec
    Start 5: greeter-test
5/6 Test #5: greeter-test .....................   Passed    1.30 sec
    Start 6: usb-snap-test
6/6 Test #6: usb-snap-test ....................   Passed    2.27 sec

100% tests passed, 0 tests failed out of 6

Total Test time (real) =   8.43 sec
[  3%] Automatic MOC for target test-utils
[  3%] Built target test-utils_autogen
[ 10%] Built target test-utils
[ 28%] Built target ayatana-indicator-display
[ 42%] Built target GMock
[ 46%] Automatic MOC for target usb-snap-test
[ 46%] Built target usb-snap-test_autogen
[ 53%] Built target usb-snap-test
[ 60%] Built target ayatana-indicator-display-service
[ 60%] Automatic MOC for target usb-manager-test
[ 60%] Built target usb-manager-test_autogen
[ 67%] Built target usb-manager-test
[ 67%] Automatic MOC for target rotation-lock-test
[ 67%] Built target rotation-lock-test_autogen
[ 67%] Generating gschemas.compiled
[ 75%] Built target rotation-lock-test
[ 75%] Automatic MOC for target adbd-client-test
[ 75%] Built target adbd-client-test_autogen
[ 78%] Generating gschemas.compiled
[ 85%] Built target adbd-client-test
[ 85%] Automatic MOC for target greeter-test
[ 85%] Built target greeter-test_autogen
[ 92%] Built target greeter-test
[ 92%] Collecting coverage data
Capturing coverage data from /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display
Found gcov version: 8.3.0
Scanning /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display for .gcda files ...
Found 7 data files in /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display
Processing ayatana-indicator-display.dir/rotation-lock.cpp.gcda
Processing ayatana-indicator-display.dir/usb-manager.cpp.gcda
Processing ayatana-indicator-display.dir/usb-snap.cpp.gcda
Processing ayatana-indicator-display.dir/greeter.cpp.gcda
Processing ayatana-indicator-display.dir/usb-monitor.cpp.gcda
Processing ayatana-indicator-display.dir/indicator.cpp.gcda
Processing ayatana-indicator-display.dir/adbd-client.cpp.gcda
Finished .info-file creation
[ 96%] Filtering recorded coverage data for project-relevant entries
Reading tracefile /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/coverage.raw.info
Extracting /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/adbd-client.cpp
Extracting /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/adbd-client.h
Extracting /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/greeter.cpp
Extracting /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/greeter.h
Extracting /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/indicator.cpp
Extracting /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/indicator.h
Extracting /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/rotation-lock.cpp
Extracting /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/usb-manager.cpp
Extracting /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/usb-monitor.cpp
Extracting /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/usb-monitor.h
Extracting /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/usb-snap.cpp
Extracted 11 files
Writing data to /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/coverage.info
Summary coverage rate:
  lines......: 81.4% (430 of 528 lines)
  functions..: 81.2% (91 of 112 functions)
  branches...: no data found
Reading tracefile /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/coverage.info
Removing /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/adbd-client.cpp
Removing /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/adbd-client.h
Removing /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/greeter.cpp
Removing /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/greeter.h
Removing /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/indicator.cpp
Removing /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/indicator.h
Removing /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/rotation-lock.cpp
Removing /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/usb-manager.cpp
Removing /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/usb-monitor.cpp
Removing /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/usb-monitor.h
Removing /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/src/usb-snap.cpp
Deleted 11 files
Writing data to /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/coverage.info
Summary coverage rate:
  lines......: no data found
  functions..: no data found
  branches...: no data found
[100%] Generating HTML coverage report in /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/coveragereport
Reading data file /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/coverage.info
genhtml: ERROR: no valid records found in tracefile /home/mike/MyDocuments/4projects/ayatana-upstream/ayatana-indicator-display.upstream/ayatana-indicator-display/coverage.info
make[3]: *** [CMakeFiles/coverage.dir/build.make:63: coveragereport] Error 255
make[2]: *** [CMakeFiles/Makefile2:149: CMakeFiles/coverage.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:156: CMakeFiles/coverage.dir/rule] Error 2
make: *** [Makefile:201: coverage] Error 2
```

Any clue where that comes from @mariogrip? What am I missing? Are coverage reports working for indicator-display as used by Ubuntu Touch?