### PR TITLE
Fix failing cppcheck

### DIFF
--- a/src/indicator.h
+++ b/src/indicator.h
@@ -64,10 +64,10 @@ public:
   SimpleProfile(const char* name, const std::shared_ptr<GMenuModel>& menu): m_name(name), m_menu(menu) {}
   virtual ~SimpleProfile();
 
-  std::string name() const {return m_name;}
+  std::string name() const override {return m_name;}
   core::Property<Header>& header() {return m_header;}
-  const core::Property<Header>& header() const {return m_header;}
-  std::shared_ptr<GMenuModel> menu_model() const {return m_menu;}
+  const core::Property<Header>& header() const override {return m_header;}
+  std::shared_ptr<GMenuModel> menu_model() const override {return m_menu;}
 
 protected:
   const std::string m_name;

--- a/src/rotation-lock.h
+++ b/src/rotation-lock.h
@@ -30,9 +30,9 @@ public:
   RotationLockIndicator();
   ~RotationLockIndicator();
 
-  const char* name() const;
-  GSimpleActionGroup* action_group() const;
-  std::vector<std::shared_ptr<Profile>> profiles() const;
+  const char* name() const override;
+  GSimpleActionGroup* action_group() const override;
+  std::vector<std::shared_ptr<Profile>> profiles() const override;
 
 protected:
   class Impl;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 add_compile_options(${CXX_WARNING_ARGS})
 
-add_test(cppcheck cppcheck --enable=all -USCHEMA_DIR --error-exitcode=2 --inline-suppr -I${CMAKE_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests)
+add_test(cppcheck cppcheck --enable=all -USCHEMA_DIR --error-exitcode=2 --inline-suppr --library=qt -I${CMAKE_SOURCE_DIR} -i${CMAKE_SOURCE_DIR}/tests/utils/qmain.cpp ${CMAKE_SOURCE_DIR}/tests --suppress=missingIncludeSystem --suppress=uninitDerivedMemberVar)
 
 add_subdirectory(integration)
 add_subdirectory(unit)

--- a/tests/unit/adbd-client-test.cpp
+++ b/tests/unit/adbd-client-test.cpp
@@ -38,7 +38,7 @@ protected:
 
     std::shared_ptr<std::string> m_tmpdir;
 
-    void SetUp()
+    void SetUp() override
     {
         super::SetUp();
 
@@ -86,7 +86,7 @@ TEST_F(AdbdClientFixture, SocketPlumbing)
         EXPECT_EQ(test.expected_pk, pk);
         ASSERT_EQ(1, adbd_server->m_responses.size());
         EXPECT_EQ(test.expected_response, adbd_server->m_responses.front());
-   
+
         // cleanup
         connection.disconnect();
         adbd_client.reset();

--- a/tests/unit/rotation-lock-test.cpp
+++ b/tests/unit/rotation-lock-test.cpp
@@ -28,12 +28,12 @@ private:
 
 protected:
 
-  void SetUp()
+  void SetUp() override
   {
     super::SetUp();
   }
 
-  void TearDown()
+  void TearDown() override
   {
     super::TearDown();
   }


### PR DESCRIPTION
- tests/CMakeLists.txt: exclude qmain.cpp + suppress system includes
- tests/unit/rotation-lock-test.cpp: Add missing override specifiers
- tests/unit/adbd-client-test.cpp: Add missing override specifiers
- src/indicator.h: Add missing override specifiers
- src/rotation-lock.h: Add missing override specifiers