### PR TITLE
Fix failing build

### DIFF
--- a/src/rotation-lock.cpp
+++ b/src/rotation-lock.cpp
@@ -171,21 +171,6 @@ private:
     return G_MENU_MODEL(menu);
   }
 
-  GMenuModel* create_desktop_menu()
-  {
-    GMenu* menu;
-    GMenuItem* menu_item;
-
-    menu = g_menu_new();
-
-    menu_item = g_menu_item_new(_("Rotation Lock"), "indicator.rotation-lock");
-    g_menu_item_set_attribute(menu_item, "x-ayatana-type", "s", "org.ayatana.indicator.switch");
-    g_menu_append_item(menu, menu_item);
-    g_object_unref(menu_item);
-
-    return G_MENU_MODEL(menu);
-  }
-
   void update_phone_header()
   {
     Header h;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 
 add_compile_options(${CXX_WARNING_ARGS})
 
-add_test(cppcheck cppcheck --enable=all -USCHEMA_DIR --error-exitcode=2 --inline-suppr --library=qt -I${CMAKE_SOURCE_DIR} -i${CMAKE_SOURCE_DIR}/tests/utils/qmain.cpp -i${CMAKE_SOURCE_DIR}/tests/gmock ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests --suppress=missingIncludeSystem)
+add_test(cppcheck cppcheck --enable=all -USCHEMA_DIR --error-exitcode=2 --inline-suppr --library=qt -I${CMAKE_SOURCE_DIR} -i${CMAKE_SOURCE_DIR}/tests/utils/qmain.cpp -i${CMAKE_SOURCE_DIR}/tests/gmock ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests --suppress=missingIncludeSystem --suppress=uninitDerivedMemberVar --suppress=unmatchedSuppression)
 
 add_subdirectory(integration)
 add_subdirectory(unit)

--- a/tests/unit/rotation-lock-test.cpp
+++ b/tests/unit/rotation-lock-test.cpp
@@ -53,9 +53,12 @@ TEST_F(RotationLockFixture, CheckIndicator)
   ASSERT_TRUE(g_action_group_has_action(G_ACTION_GROUP(actions), "rotation-lock"));
 
   std::vector<std::shared_ptr<Profile>> profiles = indicator.profiles();
-  ASSERT_EQ(1, profiles.size());
+  ASSERT_EQ(2, profiles.size());
   std::shared_ptr<Profile> phone = profiles[0];
   ASSERT_EQ(std::string("phone"), phone->name());
   ASSERT_FALSE(phone->header()->is_visible);
+  std::shared_ptr<Profile> desktop = profiles[1];
+  ASSERT_EQ(std::string("desktop"), desktop->name());
+  ASSERT_TRUE(desktop->header()->is_visible);
 }
 


### PR DESCRIPTION
- src/rotation-lock.cpp: Fix double declaration of create_desktop_menu
- tests/CMakeLists.txt: Add uninitDerivedMemberVar suppression to cppcheck
- tests/unit/rotation-lock-test.cpp: Fix and expand test

fixes https://github.com/AyatanaIndicators/ayatana-indicator-display/issues/24