### PR TITLE
GSettings: Use org.ayatana.display.gschema.xml for non-Lomiri session…

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -1,12 +1,21 @@
 find_package(GSettings)
 
 ##
-## GSettings
+## GSettings schema
 ##
 
-if(NOT EXISTS /usr/share/glib-2.0/schemas/com.lomiri.touch.system.gschema.xml)
-  add_schema ("org.ayatana.indicator.display.gschema.xml")
-endif()
+set (SCHEMA_NAME "org.ayatana.display.gschema.xml")
+set (SCHEMA_FILE "${CMAKE_CURRENT_BINARY_DIR}/${SCHEMA_NAME}")
+set (SCHEMA_FILE_IN "${CMAKE_CURRENT_SOURCE_DIR}/${SCHEMA_NAME}.in")
+
+# generate the .xml file using intltool
+find_package(Intltool REQUIRED)
+set (ENV{LC_ALL} "C")
+intltool_merge_translations("${SCHEMA_FILE_IN}" "${SCHEMA_FILE}" ALL UTF8 STYLE "xml" NO_TRANSLATIONS)
+
+# let GSettings do the rest
+find_package(GSettings REQUIRED)
+add_schema (${SCHEMA_NAME})
 
 ##
 ##  Systemd Unit File

--- a/data/org.ayatana.display.gschema.xml.in
+++ b/data/org.ayatana.display.gschema.xml.in
@@ -10,15 +10,15 @@
   <schema id="org.ayatana.indicator.display" path="/org/ayatana/indicator/display/">
     <key name="rotation-lock" type="b">
       <default>false</default>
-      <summary>Lock rotation</summary>
-      <description>
+      <_summary>Lock rotation</_summary>
+      <_description>
       Lock automatic display rotation.
-      </description>
+      </_description>
     </key>
     <key name="orientation-lock" enum="org.ayatana.indicator.display.ScreenOrientation">
       <default>"none"</default>
-      <summary>Orientation lock</summary>
-      <description>Locks orientation to a specific value.</description>
+      <_summary>Orientation lock</_summary>
+      <_description>Locks orientation to a specific value.</_description>
     </key>
   </schema>
 </schemalist>

--- a/src/rotation-lock.cpp
+++ b/src/rotation-lock.cpp
@@ -38,16 +38,24 @@ public:
 
     if (pSource != NULL)
     {
-        GSettingsSchema *pSchema = g_settings_schema_source_lookup(pSource, "com.lomiri.touch.system", FALSE);
+        if (ayatana_common_utils_is_lomiri()) {
 
-        if (pSchema != NULL)
-        {
-            g_settings_schema_unref(pSchema);
-            m_settings = g_settings_new("com.lomiri.touch.system");
+            GSettingsSchema *pSchema = g_settings_schema_source_lookup(pSource, "com.lomiri.touch.system", FALSE);
+
+            if (pSchema != NULL)
+            {
+                g_settings_schema_unref(pSchema);
+                m_settings = g_settings_new("com.lomiri.touch.system");
+            }
+            else
+            {
+                g_error("No schema could be found");
+            }
+
         }
-        else
-        {
-            pSchema = g_settings_schema_source_lookup(pSource, "org.ayatana.indicator.display", FALSE);
+        else {
+
+            GSettingsSchema *pSchema = g_settings_schema_source_lookup(pSource, "org.ayatana.indicator.display", FALSE);
 
             if (pSchema != NULL)
             {
@@ -58,6 +66,7 @@ public:
             {
                 g_error("No schema could be found");
             }
+
         }
     }
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -12,16 +12,13 @@ set_source_files_properties (gschemas.compiled GENERATED)
 # and help the tests to find that file by setting -DSCHEMA_DIR
 set (XDG_DATA_DIRS "${CMAKE_CURRENT_BINARY_DIR}/gsettings-schemas")
 set (SCHEMA_DIR "${XDG_DATA_DIRS}/glib-2.0/schemas")
-if (EXISTS /usr/share/glib-2.0/schemas/com.lomiri.touch.system.gschema.xml)
-  set (DISPLAY_SCHEMA /usr/share/glib-2.0/schemas/com.lomiri.touch.system.gschema.xml)
-else()
-  set (DISPLAY_SCHEMA ${CMAKE_SOURCE_DIR}/data/org.ayatana.display.gschema.xml)
-endif()
+set (DISPLAY_SCHEMA ${CMAKE_BINARY_DIR}/data/org.ayatana.display.gschema.xml)
 add_definitions(-DSCHEMA_DIR="${SCHEMA_DIR}")
 execute_process (COMMAND ${PKG_CONFIG_EXECUTABLE} gio-2.0 --variable glib_compile_schemas
                  OUTPUT_VARIABLE COMPILE_SCHEMA_EXECUTABLE
                  OUTPUT_STRIP_TRAILING_WHITESPACE)
 add_custom_command (OUTPUT gschemas.compiled
+                    DEPENDS ${CMAKE_BINARY_DIR}/data/org.ayatana.display.gschema.xml
                     COMMAND mkdir -p ${SCHEMA_DIR}
                     COMMAND cp -f ${DISPLAY_SCHEMA} ${SCHEMA_DIR}
                     COMMAND ${COMPILE_SCHEMA_EXECUTABLE} ${SCHEMA_DIR})


### PR DESCRIPTION
…s and unit tests.

 Additionally, internationalize the org.ayatana.display GSettings schema.

 Fixes https://github.com/AyatanaIndicators/ayatana-indicator-display/issues/39