### PR TITLE
Fix wrong Exec= in .desktop file

### DIFF
--- a/data/ayatana-indicator-display.desktop.in
+++ b/data/ayatana-indicator-display.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=Ayatana Indicator Display
-Exec=@CMAKE_INSTALL_FULL_LIBEXECDIR@/ayatana-indicator-display-service
+Exec=@CMAKE_INSTALL_FULL_LIBEXECDIR@/ayatana-indicator-display/ayatana-indicator-display-service
 OnlyShowIn=Unity;MATE;XFCE;Budgie:GNOME;
 NoDisplay=true
 StartupNotify=false


### PR DESCRIPTION
Previously it was pointing to the path
  /usr/libexec/ayatana-indicator-display-service
instead of
  /usr/libexec/ayatana-indicator-display/ayatana-indicator-display-service

Align the implementation with ayatana-indicator-datetime