### PR TITLE
src/rotation-lock.cpp: Add tooltip, rename indicator title from 'Rota…

### DIFF
--- a/src/indicator.h
+++ b/src/indicator.h
@@ -32,6 +32,7 @@ struct Header
   std::string title;
   std::string label;
   std::string a11y;
+  std::string tooltip;
   std::shared_ptr<GIcon> icon;
 
   bool operator== (const Header& that) const {

--- a/src/rotation-lock.cpp
+++ b/src/rotation-lock.cpp
@@ -213,6 +213,7 @@ private:
   {
     Header h;
     h.title = _("Rotation");
+    h.tooltip = h.title;
     h.a11y = h.title;
     h.is_visible = g_settings_get_boolean(m_settings, "rotation-lock");
     h.icon = m_icon;
@@ -222,7 +223,8 @@ private:
   void update_desktop_header()
   {
     Header h;
-    h.title = _("Rotation");
+    h.title = _("Display");
+    h.tooltip = _("Display settings and features");
     h.a11y = h.title;
     h.is_visible = TRUE;
     h.icon = m_icon;


### PR DESCRIPTION
…tion' to 'Display' on desktops.