### PR TITLE
src/rotation-lock.cpp: Prefer a symbolic panel icon

### DIFF
--- a/src/rotation-lock.cpp
+++ b/src/rotation-lock.cpp
@@ -77,7 +77,7 @@ public:
 
     if (!ayatana_common_utils_is_lomiri())
     {
-        rotation_lock_icon_name = "display";
+        rotation_lock_icon_name = "display-panel";
     }
 
     auto icon = g_themed_icon_new_with_default_fallbacks(rotation_lock_icon_name);


### PR DESCRIPTION
This changes the icon search order from

display,
[no icon]

to

display-panel,
display,
[no icon]