### PR TITLE
Fix access of unitialized variables in DisplayIndicator destructor

### DIFF
--- a/src/service.cpp
+++ b/src/service.cpp
@@ -1141,8 +1141,8 @@ private:
   GSettings *pMetacitySettings = NULL;
   GSettings *pColorSchemeSettings = NULL;
   gboolean bTest;
-  guint nGreeterSubscription;
-  GDBusConnection *pConnection;
+  guint nGreeterSubscription = 0;
+  GDBusConnection *pConnection = NULL;
   gchar *sUser = NULL;
   GSList *lUsers = NULL;
   gboolean bReadingAccountsService = FALSE;


### PR DESCRIPTION
In the constructor nGreeterSubscription and pConnection are only initialized if bGreeter is true whereas the destructor always accesses them and possibly passes uninitialized values to functions.