### PR TITLE
src/service.cpp: Look up schemas recursively

### DIFF
--- a/src/service.cpp
+++ b/src/service.cpp
@@ -76,7 +76,7 @@ public:
     {
         if (ayatana_common_utils_is_lomiri()) {
 
-            GSettingsSchema *pSchema = g_settings_schema_source_lookup(pSource, "com.lomiri.touch.system", FALSE);
+            GSettingsSchema *pSchema = g_settings_schema_source_lookup(pSource, "com.lomiri.touch.system", TRUE);
 
             if (pSchema != NULL)
             {
@@ -91,7 +91,7 @@ public:
         }
         else {
 
-            GSettingsSchema *pSchema = g_settings_schema_source_lookup(pSource, "org.ayatana.indicator.display", FALSE);
+            GSettingsSchema *pSchema = g_settings_schema_source_lookup(pSource, "org.ayatana.indicator.display", TRUE);
 
             if (pSchema != NULL)
             {
@@ -134,7 +134,7 @@ public:
                     }
                 }
 
-                pSchema = g_settings_schema_source_lookup (pSource, sSchema, FALSE);
+                pSchema = g_settings_schema_source_lookup (pSource, sSchema, TRUE);
 
                 if (pSchema != NULL)
                 {
@@ -146,7 +146,7 @@ public:
                     g_error("No %s schema could be found", sSchema);
                 }
 
-                pSchema = g_settings_schema_source_lookup (pSource, sCursorSchema, FALSE);
+                pSchema = g_settings_schema_source_lookup (pSource, sCursorSchema, TRUE);
 
                 if (pSchema != NULL)
                 {
@@ -158,7 +158,7 @@ public:
                     g_error("No %s schema could be found", sCursorSchema);
                 }
 
-                pSchema = g_settings_schema_source_lookup (pSource, sMetacitySchema, FALSE);
+                pSchema = g_settings_schema_source_lookup (pSource, sMetacitySchema, TRUE);
 
                 if (pSchema != NULL)
                 {
@@ -179,7 +179,7 @@ public:
                     sSchema = "org.gnome.desktop.interface";
                 }
 
-                pSchema = g_settings_schema_source_lookup (pSource, sSchema, FALSE);
+                pSchema = g_settings_schema_source_lookup (pSource, sSchema, TRUE);
 
                 if (pSchema != NULL)
                 {


### PR DESCRIPTION
[`g_settings_schema_source_get_default(void)`](https://docs.gtk.org/gio/type_func.SettingsSchemaSource.get_default.html) documentation says that the returned source may consist of multiple sources from different directories, and that lookups against the default source should be done recursively to cover this situation.

In Nixpkgs, we wrap this indicator by putting paths to the different schemas it might need into `XDG_DATA_DIRS` / `GSETTINGS_SCHEMA_DIR`. Without this recursive lookup, only the first directory in that list is checked.