### PR TITLE
Fix failure with recent cppcheck

### DIFF
--- a/src/service.cpp
+++ b/src/service.cpp
@@ -1058,7 +1058,7 @@ private:
     static_cast<Impl*>(gself)->update_phone_header();
   }
 
-  GMenuModel* create_phone_menu()
+  static GMenuModel* create_phone_menu()
   {
     GMenu* menu;
     GMenu* section;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 add_compile_options(${CXX_WARNING_ARGS})
 
-add_test(cppcheck cppcheck --enable=all -USCHEMA_DIR --check-level=exhaustive --error-exitcode=2 --inline-suppr --library=qt -I${CMAKE_SOURCE_DIR} -i${CMAKE_SOURCE_DIR}/tests/utils/qmain.cpp -i${CMAKE_SOURCE_DIR}/tests/gmock ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests --suppress=missingIncludeSystem --suppress=uninitDerivedMemberVar --suppress=unmatchedSuppression --suppress=constParameter --suppress=constParameterCallback --suppress=unusedFunction --suppress=uselessOverride)
+add_test(cppcheck cppcheck --enable=all -USCHEMA_DIR --check-level=exhaustive --error-exitcode=2 --inline-suppr --library=qt --library=${CMAKE_SOURCE_DIR}/tests/ayatana.cfg -I${CMAKE_SOURCE_DIR} -i${CMAKE_SOURCE_DIR}/tests/utils/qmain.cpp -i${CMAKE_SOURCE_DIR}/tests/gmock ${CMAKE_SOURCE_DIR}/src ${CMAKE_SOURCE_DIR}/tests --suppress=missingIncludeSystem --suppress=uninitDerivedMemberVar --suppress=unmatchedSuppression --suppress=constParameter --suppress=constParameterCallback --suppress=unusedFunction --suppress=uselessOverride)
 
 add_subdirectory (unit)
 

--- a/tests/ayatana.cfg
+++ b/tests/ayatana.cfg
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<def format="2">
+  <!-- cppcheck override copied from gtk.cfg -->
+  <define name="GLIB_CHECK_VERSION(major, minor, micro)" value="1"/>
+</def>


### PR DESCRIPTION
ayatana-indicator-display is failing to build in Debian Unstable and Ubuntu 26.04 LTS (devel) because of a change in cppcheck.

I first tried including gtk.cfg which has the snippet we need. However, including gtk.cfg changes other details in how cppcheck is run and it triggered other errors. So I created a simple .cfg file to include the one line we need.

After fixing that error, there was one other error that needed to be fix for cppcheck to succeed so I marked the function as static.

- https://bugs.debian.org/1125642
- #106 